### PR TITLE
feat: add fetching of paginated products and orders

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    samcart_api (0.1.2)
+    samcart_api (0.2.0)
       activesupport (>= 6.0)
       faraday (~> 2.0)
       json (~> 2.0)

--- a/lib/samcart_api.rb
+++ b/lib/samcart_api.rb
@@ -18,6 +18,7 @@ module SamcartApi
   autoload :Order, 'samcart_api/order'
   autoload :Client, 'samcart_api/client'
   autoload :ApiRequest, 'samcart_api/api_request'
+  autoload :Paginator, 'samcart_api/paginator'
 
   class << self
     def configure

--- a/lib/samcart_api/api_request.rb
+++ b/lib/samcart_api/api_request.rb
@@ -2,6 +2,8 @@
 
 module SamcartApi
   class ApiRequest
+    RETRY_ATTEMPTS = 3
+
     def initialize(method, path, params, api_key)
       @method = method
       @path = path
@@ -11,6 +13,12 @@ module SamcartApi
     end
 
     def perform
+      safe_request { make_request }
+    end
+
+    private
+
+    def make_request
       response = connection.send(@method) do |req|
         req.url "/#{@version}#{@path}"
         req.params = @params if @params
@@ -22,7 +30,30 @@ module SamcartApi
       handle_response(response)
     end
 
-    private
+    def safe_request
+      retries = 0
+
+      begin
+        yield
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
+        puts "Network error: #{e.message}. Retrying..."
+        sleep 2
+        retries += 1
+        retry if retries < RETRY_ATTEMPTS
+        raise 'Too many retries: Network issues'
+      rescue ApiError => e
+        if e.message.include?('Too Many Requests') # Custom handling for 429
+          wait_time = 5 # Default wait
+          puts "Rate limited! Retrying in #{wait_time} seconds..."
+          sleep wait_time
+          retries += 1
+          retry if retries < RETRY_ATTEMPTS
+          raise 'Too many retries: Rate limited'
+        else
+          raise
+        end
+      end
+    end
 
     def connection
       @connection ||= Faraday.new(url: SamcartApi.configuration.api_url) do |conn|
@@ -41,6 +72,8 @@ module SamcartApi
         raise AuthenticationError, 'Access denied'
       when 404
         raise ApiError, 'Resource not found'
+      when 429
+        raise ApiError, 'Too Many Requests'
       else
         raise ApiError, "API request failed: #{response.body["message"] || response.body}"
       end

--- a/lib/samcart_api/order.rb
+++ b/lib/samcart_api/order.rb
@@ -6,25 +6,17 @@ module SamcartApi
 
     class << self
       def find(id)
-        new(id).find
+        order = client.get("#{RESOURCE_PATH}/#{id}")
+        SamcartApi::SamcartObject.new(order)
       end
-    end
 
-    def initialize(id)
-      @id = id
-    end
+      def client
+        @client ||= SamcartApi::Client.new
+      end
 
-    def find
-      order = client.get("#{RESOURCE_PATH}/#{id}")
-      SamcartApi::SamcartObject.new(order)
-    end
-
-    private
-
-    attr_reader :id
-
-    def client
-      @client ||= SamcartApi::Client.new
+      def all(limit: 100)
+        SamcartApi::Paginator.new(client, RESOURCE_PATH, limit)
+      end
     end
   end
 end

--- a/lib/samcart_api/paginator.rb
+++ b/lib/samcart_api/paginator.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module SamcartApi
+  class Paginator
+    def initialize(client, path, limit = 100)
+      @client = client
+      @next_url = "#{path}?limit=#{limit}"
+      @retry_attempts = 3
+    end
+
+    def next_page?
+      !@next_url.nil?
+    end
+
+    def next_page
+      return unless next_page?
+
+      response = client.get(@next_url)
+      @next_url = response.dig('pagination', 'next')
+      response['data']
+    end
+
+    def each_page
+      yield next_page while next_page?
+    end
+
+    attr_reader :client
+  end
+end

--- a/lib/samcart_api/product.rb
+++ b/lib/samcart_api/product.rb
@@ -6,25 +6,17 @@ module SamcartApi
 
     class << self
       def find(id)
-        new(id).find
+        product = client.get("#{RESOURCE_PATH}/#{id}")
+        SamcartApi::SamcartObject.new(product)
       end
-    end
 
-    def initialize(id)
-      @id = id
-    end
+      def client
+        @client ||= SamcartApi::Client.new
+      end
 
-    def find
-      product = client.get("#{RESOURCE_PATH}/#{id}")
-      SamcartApi::SamcartObject.new(product)
-    end
-
-    private
-
-    attr_reader :id
-
-    def client
-      @client ||= SamcartApi::Client.new
+      def all(limit: 100)
+        SamcartApi::Paginator.new(client, RESOURCE_PATH, limit)
+      end
     end
   end
 end

--- a/samcart_api.gemspec
+++ b/samcart_api.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'samcart_api'
-  spec.version       = '0.1.2'
+  spec.version       = '0.2.0'
   spec.authors       = ['Olumuyiwa Osiname']
   spec.email         = ['osiname@gmail.com']
 

--- a/spec/samcart_api/order_spec.rb
+++ b/spec/samcart_api/order_spec.rb
@@ -63,12 +63,12 @@ RSpec.describe SamcartApi::Order do
     }
   end
 
-  before do
-    allow(SamcartApi::Client).to receive(:new).and_return(client)
-    allow(client).to receive(:get).and_return(order_data)
-  end
+  describe '.find' do
+    before do
+      allow(SamcartApi::Client).to receive(:new).and_return(client)
+      allow(client).to receive(:get).with('/orders/1337').and_return(order_data)
+    end
 
-  describe '#find' do
     it 'returns a single Order instance' do
       order = described_class.find('1337')
 
@@ -94,5 +94,9 @@ RSpec.describe SamcartApi::Order do
         },
       ])
     end
+  end
+
+  describe '.all' do
+    it_behaves_like 'a paginated API resource', resource_path: '/orders'
   end
 end

--- a/spec/samcart_api/paginator_spec.rb
+++ b/spec/samcart_api/paginator_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SamcartApi::Paginator do
+  let(:client) { instance_double(SamcartApi::Client) }
+  let(:limit) { 3 } # Number of items per page
+  let(:total_resources) { 10 }
+  let(:path) { '/resource' }
+
+  let(:resources_data) do
+    Array.new(total_resources) { |i| { 'id' => i + 1, 'name' => "resource ##{i + 1}" } }
+  end
+
+  before do
+    allow(client).to receive(:get).and_return(stub_paginated_response(1, limit))
+  end
+
+  def stub_paginated_response(page, per_page)
+    start_index = (page - 1) * per_page
+    end_index = start_index + per_page - 1
+
+    {
+      'data' => resources_data[start_index..end_index] || [],
+      'pagination' => {
+        'next' => end_index < total_resources - 1 ? "/resources?page=#{page + 1}&limit=#{per_page}" : nil,
+      },
+    }
+  end
+
+  it 'fetches paginated resources correctly using `next_page`' do
+    # Stub paginated responses dynamically
+    (1..4).each do |page|
+      response = stub_paginated_response(page, limit)
+      allow(client).to receive(:get).with("/resources?page=#{page}&limit=#{limit}").and_return(response)
+    end
+
+    paginator = described_class.new(client, path, limit)
+    all_resources = []
+
+    all_resources.concat(paginator.next_page) while paginator.next_page?
+
+    expect(all_resources.size).to eq(total_resources)
+    expect(all_resources.map { |o| o['id'] }).to match_array((1..10).to_a)
+  end
+
+  it 'iterates over each page using `each_page`' do
+    (1..4).each do |page|
+      response = stub_paginated_response(page, limit)
+      allow(client).to receive(:get).with("/resources?page=#{page}&limit=#{limit}").and_return(response)
+    end
+
+    paginator = described_class.new(client, path, limit)
+    all_resources = []
+
+    paginator.each_page do |page_resources|
+      all_resources.concat(page_resources)
+    end
+
+    expect(all_resources.size).to eq(total_resources)
+    expect(all_resources.map { |o| o['id'] }).to match_array((1..10).to_a)
+  end
+end

--- a/spec/samcart_api/product_spec.rb
+++ b/spec/samcart_api/product_spec.rb
@@ -45,12 +45,12 @@ RSpec.describe SamcartApi::Product do
     }
   end
 
-  before do
-    allow(SamcartApi::Client).to receive(:new).and_return(client)
-    allow(client).to receive(:get).and_return(product_data)
-  end
-
   describe '#find' do
+    before do
+      allow(SamcartApi::Client).to receive(:new).and_return(client)
+      allow(client).to receive(:get).and_return(product_data)
+    end
+
     it 'returns a single Product instance' do
       product = described_class.find('1337')
 
@@ -62,5 +62,9 @@ RSpec.describe SamcartApi::Product do
       expect(product.currency).to eq('USD')
       expect(product.price).to eq(1025)
     end
+  end
+
+  describe '#all' do
+    it_behaves_like 'a paginated API resource', resource_path: '/products'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'bundler/setup'
 require 'samcart_api'
+require 'support/shared_examples/paginated_resource'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|

--- a/spec/support/shared_examples/paginated_resource.rb
+++ b/spec/support/shared_examples/paginated_resource.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'a paginated API resource' do |resource_path|
+  let(:client) { instance_double(SamcartApi::Client) }
+  let(:limit) { 3 } # Number of items per page
+  let(:total_resources) { 10 }
+  let(:path) { resource_path }
+
+  let(:resources_data) do
+    Array.new(total_resources) { |i| { 'id' => i + 1, 'name' => "resource ##{i + 1}" } }
+  end
+
+  before do
+    allow(described_class).to receive(:client).and_return(client)
+    allow(client).to receive(:get).and_return(stub_paginated_response(1, limit))
+  end
+
+  def stub_paginated_response(page, per_page)
+    start_index = (page - 1) * per_page
+    end_index = start_index + per_page - 1
+
+    {
+      'data' => resources_data[start_index..end_index] || [],
+      'pagination' => {
+        'next' => end_index < total_resources - 1 ? "#{path}?page=#{page + 1}&limit=#{per_page}" : nil,
+      },
+    }
+  end
+
+  it 'returns a Paginator instance' do
+    paginator = described_class.all
+
+    expect(paginator).to be_a(SamcartApi::Paginator)
+  end
+
+  it 'fetches paginated resources correctly using `next_page`' do
+    # Stub paginated responses dynamically
+    (1..4).each do |page|
+      response = stub_paginated_response(page, limit)
+      allow(client).to receive(:get).with("#{path}?page=#{page}&limit=#{limit}").and_return(response)
+    end
+
+    paginator = SamcartApi::Paginator.new(client, path, limit)
+    all_resources = []
+
+    all_resources.concat(paginator.next_page) while paginator.next_page?
+
+    expect(all_resources.size).to eq(total_resources)
+    expect(all_resources.map { |o| o['id'] }).to match_array((1..10).to_a)
+  end
+
+  # it 'iterates over each page using `each_page`' do
+  #   (1..4).each do |page|
+  #     response = stub_paginated_response(page, limit)
+  #     allow(client).to receive(:get).with("#{path}?page=#{page}&limit=#{limit}").and_return(response)
+  #   end
+
+  #   paginator = described_class.all
+  #   all_resources = []
+
+  #   paginator.each_page do |page_resources|
+  #     all_resources.concat(page_resources)
+  #   end
+
+  #   expect(all_resources.size).to eq(total_resources)
+  #   expect(all_resources.map { |o| o['id'] }).to match_array((1..10).to_a)
+  # end
+
+  it 'fetches all resources using pagination' do
+    # Stub API responses for paginated requests
+    (1..4).each do |page|
+      allow(client).to receive(:get).with("#{path}?page=#{page}&limit=#{limit}").and_return(stub_paginated_response(
+        page, limit
+      ))
+    end
+
+    resources = []
+    described_class.all(limit: limit).each_page do |page_resources|
+      resources.concat(page_resources)
+    end
+
+    expect(resources.size).to eq(total_resources)
+    expect(resources.pluck('id')).to match_array((1..10).to_a)
+  end
+end


### PR DESCRIPTION
This PR introduces a Paginator class to efficiently handle paginated API requests within SamcartApi. It enables seamless fetching of orders and products by iterating through API pagination links dynamically.

**Key Changes**

- Added SamcartApi::Paginator

1. Fetches paginated results using next_page? and next_page.
2. Provides an each_page method for iterating over paginated data.
3. Supports API pagination via the pagination["next"] field.
4. Implemented SamcartApi::Order.all and SamcartApi::Product.all

- Uses the Paginator to fetch all orders and all products from the API.